### PR TITLE
Convert PPT/PPTX to PDF on upload and remove the source Office file.

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -15,8 +15,8 @@ ADMIN_PASSWORD=cbrin123
 # Session / token lifetime in hours
 SESSION_TTL_HOURS=12
 
-# Upload limits
-MAX_UPLOAD_MB=30
+# Upload limits (PPT/PPTX convert on upload; PDF preferred when possible)
+MAX_UPLOAD_MB=100
 
 # Presence / room TTL in milliseconds
 PRESENCE_TTL_MS=30000

--- a/server/README.md
+++ b/server/README.md
@@ -10,7 +10,7 @@ Replaces the single-file demo server and the Flask `:5000` screen-share dependen
 - SQLite persistence for users, idle slides, uploads, rooms, presence, presentation state, screen share
 - Demo-compatible APIs: idle slides, presentation SSE sync, presence, uploads
 - Socket.IO WebRTC signaling for screen share (same origin)
-- LibreOffice-powered `/api/convert-presentation` for PPT/PPTX → PDF
+- LibreOffice-powered PPT/PPTX → PDF conversion on upload (`POST /api/presentation-files`) and via `/api/convert-presentation`
 - Health checks, rate limits, cleanup jobs, systemd + kiosk docs
 
 ## Quick start
@@ -23,6 +23,7 @@ npm run migrate
 npm run seed-admin
 npm run generate-certs   # required for LAN screen sharing
 # ensure ENABLE_HTTPS=true in .env
+# For PPT/PPTX uploads, install LibreOffice and set LIBREOFFICE_BIN
 npm start
 ```
 
@@ -32,6 +33,8 @@ Open:
 - Idle: `https://localhost:3000/idle`
 - Presentation: `https://localhost:3000/presentation`
 - Health: `https://localhost:3000/api/health`
+
+**Uploads:** default limit is `MAX_UPLOAD_MB=100`. PPT/PPTX are converted to PDF on the server during upload (requires LibreOffice). Prefer uploading PDF when you can.
 
 **Screen sharing:** browsers block capture on `http://LAN-IP`. Use HTTPS (above) or open presentation on the presenting PC via `https://localhost:3000/presentation`.
 
@@ -68,7 +71,7 @@ See [deploy/DEPLOY.md](deploy/DEPLOY.md) for systemd, firewall, backup, and Libr
 | POST | `/api/auth/login` | no | Admin login |
 | GET | `/api/auth/me` | yes | Current admin |
 | GET/POST/DELETE | `/api/idle-slides` | write=yes | Billboard CRUD |
-| POST | `/api/presentation-files` | no | Upload PDF/PPT/PPTX |
+| POST | `/api/presentation-files` | no | Upload PDF/PPT/PPTX (PPT→PDF on upload) |
 | GET | `/api/presentation-events` | no | SSE sync |
 | POST | `/api/presentation-presence` | clear-room=yes | Join/leave/clear |
 | POST | `/api/presentation-command` | no | start/sync/exit |

--- a/server/public/presentation_cbrin_mobile_display.html
+++ b/server/public/presentation_cbrin_mobile_display.html
@@ -711,7 +711,7 @@
           </div>
           <div id="uploadedFileList" class="upload-list page-upload-list" style="margin-top:10px;"></div>
           <div class="upload-note">
-            PDF files will open in the presentation viewer. PPTX files will be read by a simple built-in text slide reader. Legacy .ppt files can be uploaded but need a backend converter for true slide preview.
+            PDF files open in the presentation viewer. PowerPoint (.ppt / .pptx) is converted to PDF on the server during upload (LibreOffice required on the room PC). Limit: 100 MB.
           </div>
         </div>
       </div>
@@ -1182,13 +1182,13 @@
       if (el) el.classList.remove('show');
     }
 
-    function showToast(text) {
+    function showToast(text, durationMs = 2200) {
       const toast = document.getElementById('toast');
       if (!toast) return;
       toast.textContent = text;
       toast.style.display = 'block';
       clearTimeout(showToast.timer);
-      showToast.timer = setTimeout(() => toast.style.display = 'none', 2200);
+      showToast.timer = setTimeout(() => toast.style.display = 'none', durationMs);
     }
 
     function escapeHtml(value) {
@@ -1197,14 +1197,36 @@
 
     async function uploadPresentationToBackend(item) {
       if (!item || item.serverUrl || !item.file) return item;
+      const needsConvert = item.type === 'ppt' || item.type === 'pptx';
+      if (needsConvert) showToast('Uploading and converting to PDF…', 60000);
       const formData = new FormData();
       formData.append('file', item.file, item.name);
       const res = await fetch(BACKEND_UPLOAD_ENDPOINT, { method: 'POST', body: formData });
-      if (!res.ok) throw new Error(await res.text());
-      const saved = await res.json();
+      const raw = await res.text();
+      let saved = {};
+      try { saved = raw ? JSON.parse(raw) : {}; } catch (_e) { saved = { error: raw || 'Upload failed' }; }
+      if (!res.ok) {
+        const parts = [saved.error || raw || 'Upload failed'];
+        if (saved.hint) parts.push(saved.hint);
+        throw new Error(parts.join(' — '));
+      }
       item.serverUrl = saved.url;
       item.remoteUrl = saved.url;
       item.remoteId = saved.id;
+      if (saved.type) item.type = String(saved.type).toLowerCase();
+      if (saved.name) item.name = saved.name;
+      if (Number.isFinite(Number(saved.size))) item.size = Number(saved.size);
+      if (saved.url) item.url = saved.url;
+      if (saved.converted) {
+        item.convertedUrl = saved.url;
+        item.convertedId = saved.id;
+        item.sourceId = saved.sourceId || null;
+        item.parseStatus = 'ready';
+        item.slides = null;
+        showToast('Converted to PDF and ready to present', 3200);
+      } else if (needsConvert) {
+        showToast('Upload complete', 2200);
+      }
       return item;
     }
 
@@ -1623,28 +1645,26 @@
           url: URL.createObjectURL(file),
           size: file.size,
           slides: null,
-          parseStatus: type === 'pptx' ? 'pending' : 'ready'
+          parseStatus: type === 'pdf' ? 'ready' : 'pending'
         };
         uploadedPresentations.push(item);
         selectedPresentationId = item.id;
-        uploadPresentationToBackend(item).then(() => renderUploadedFiles()).catch(err => {
+        uploadPresentationToBackend(item).then(() => {
+          // Server converts PPT/PPTX to PDF on upload; treat as PDF-ready.
+          if (item.type === 'pdf') {
+            item.parseStatus = 'ready';
+            item.slides = null;
+          }
+          renderUploadedFiles();
+        }).catch(err => {
           console.warn('Backend upload failed:', err);
-          showError('uploadError', 'Upload was added locally, but it could not be shared to the display computer: ' + err.message);
+          item.parseStatus = 'failed';
+          renderUploadedFiles();
+          showError('uploadError', 'Upload failed: ' + (err.message || 'server error. For PowerPoint, install LibreOffice on the room PC.'));
         });
-        if (type === 'pptx') {
-          parsePptxSlides(item).then(() => renderUploadedFiles()).catch(() => {
-            item.parseStatus = 'failed';
-            renderUploadedFiles();
-          });
-        }
       }
       renderUploadedFiles();
       showToast(validFiles.length + ' file(s) added');
-
-      // Backend hook for later database/file storage support:
-      // const formData = new FormData();
-      // validFiles.forEach(file => formData.append('files', file));
-      // await fetch(BACKEND_UPLOAD_ENDPOINT, { method: 'POST', body: formData });
     }
 
     function formatBytes(bytes) {

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -20,7 +20,7 @@ const config = {
   adminUsername: process.env.ADMIN_USERNAME || 'admin',
   adminPassword: process.env.ADMIN_PASSWORD || 'cbrin123',
   sessionTtlHours: Number(process.env.SESSION_TTL_HOURS || 12),
-  maxUploadMb: Number(process.env.MAX_UPLOAD_MB || 30),
+  maxUploadMb: Number(process.env.MAX_UPLOAD_MB || 100),
   presenceTtlMs: Number(process.env.PRESENCE_TTL_MS || 30000),
   roomExpireHours: Number(process.env.ROOM_EXPIRE_HOURS || 12),
   cleanupIntervalMs: Number(process.env.CLEANUP_INTERVAL_MS || 900000),

--- a/server/src/routes/convert.js
+++ b/server/src/routes/convert.js
@@ -4,7 +4,7 @@ const express = require('express');
 const { optionalAuth } = require('../middleware/auth');
 const { presentationUpload } = require('../middleware/upload');
 const { asyncHandler } = require('../middleware/errors');
-const { convertPresentation } = require('../services/conversionService');
+const { convertPresentation, removeSourceOfficeFile } = require('../services/conversionService');
 const { getDb } = require('../db');
 const { config } = require('../config');
 
@@ -77,6 +77,7 @@ router.post(
         )
         .get(sourceId);
       if (existing && existing.file_path && fs.existsSync(existing.file_path)) {
+        removeSourceOfficeFile(sourceId, { promotePdfId: existing.id });
         return res.json({
           ok: true,
           id: existing.id,

--- a/server/src/routes/presentations.js
+++ b/server/src/routes/presentations.js
@@ -7,6 +7,7 @@ const { asyncHandler } = require('../middleware/errors');
 const { getValidSession, extractToken } = require('../middleware/auth');
 const { attachEvents, handleCommand } = require('../services/presentationSync');
 const { handlePresence } = require('../services/roomManager');
+const { convertPresentation } = require('../services/conversionService');
 
 const router = express.Router();
 
@@ -102,20 +103,64 @@ router.post(
     const ext = path.extname(file.originalname || '').toLowerCase().replace('.', '') || 'pdf';
     const id = `${Date.now().toString(36)}-${uuidv4().slice(0, 8)}`;
     const url = `/presentation_uploads/${file.filename}`;
+    const originalName = file.originalname || file.filename;
     getDb()
       .prepare(
         `INSERT INTO uploaded_files
            (id, filename, file_type, file_path, public_url, size, status, uploaded_by, uploaded_at)
          VALUES (?, ?, ?, ?, ?, ?, 'uploaded', ?, datetime('now'))`
       )
-      .run(id, file.originalname || file.filename, ext, file.path, url, file.size || 0, null);
+      .run(id, originalName, ext, file.path, url, file.size || 0, null);
+
+    // PDF uploads are ready immediately.
+    if (ext === 'pdf') {
+      return res.status(201).json({
+        id,
+        name: originalName,
+        type: 'pdf',
+        size: file.size || 0,
+        url,
+        converted: false,
+      });
+    }
+
+    // PPT/PPTX: convert to PDF on upload so Start Presentation can use PDF.js directly.
+    if (ext === 'ppt' || ext === 'pptx') {
+      try {
+        const converted = await convertPresentation({
+          sourcePath: file.path,
+          originalName,
+          sourceId: id,
+          uploadedBy: 'controller',
+        });
+        return res.status(201).json({
+          id: converted.id,
+          name: converted.name || converted.filename || originalName.replace(/\.(ppt|pptx)$/i, '.pdf'),
+          type: 'pdf',
+          size: converted.size || 0,
+          url: converted.url,
+          sourceName: originalName,
+          converted: true,
+          status: converted.status || 'ready',
+        });
+      } catch (err) {
+        const status = /LibreOffice failed to start/i.test(err.message) ? 503 : 500;
+        return res.status(status).json({
+          ok: false,
+          error: err.message,
+          hint: 'Install LibreOffice and set LIBREOFFICE_BIN in .env',
+          sourceId: id,
+        });
+      }
+    }
 
     res.status(201).json({
       id,
-      name: file.originalname || file.filename,
+      name: originalName,
       type: ext,
       size: file.size || 0,
       url,
+      converted: false,
     });
   })
 );

--- a/server/src/services/conversionService.js
+++ b/server/src/services/conversionService.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { spawn } = require('child_process');
 const { v4: uuidv4 } = require('uuid');
 const { config } = require('../config');
@@ -8,32 +9,65 @@ const { getDb } = require('../db');
 const queue = [];
 let running = false;
 
+function toFileUrl(absolutePath) {
+  const normalized = path.resolve(absolutePath).replace(/\\/g, '/');
+  // LibreOffice UserInstallation expects a file:// URL.
+  if (normalized.startsWith('/')) return `file://${normalized}`;
+  return `file:///${normalized}`;
+}
+
 function runLibreOffice(inputPath, outDir) {
   return new Promise((resolve, reject) => {
     const bin = config.libreOfficeBin;
+    // macOS/headless LO often fails with "source file could not be loaded" when the
+    // default user profile is locked (GUI open, stale lock, concurrent converts).
+    const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lo-profile-'));
     const args = [
       '--headless',
       '--nologo',
       '--nolockcheck',
       '--nodefault',
       '--nofirststartwizard',
+      `-env:UserInstallation=${toFileUrl(profileDir)}`,
       '--convert-to',
       'pdf',
       '--outdir',
       outDir,
-      inputPath,
+      path.resolve(inputPath),
     ];
-    const child = spawn(bin, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(bin, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        HOME: process.env.HOME || os.homedir(),
+      },
+    });
+    let stdout = '';
     let stderr = '';
+    child.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
     child.stderr.on('data', (d) => {
       stderr += d.toString();
     });
     child.on('error', (err) => {
+      try {
+        fs.rmSync(profileDir, { recursive: true, force: true });
+      } catch (_e) {
+        /* ignore */
+      }
       reject(new Error(`LibreOffice failed to start (${bin}): ${err.message}`));
     });
     child.on('close', (code) => {
+      try {
+        fs.rmSync(profileDir, { recursive: true, force: true });
+      } catch (_e) {
+        /* ignore */
+      }
+      // Fontconfig warnings are common and harmless; only fail on non-zero exit.
       if (code !== 0) {
-        reject(new Error(`LibreOffice exited with code ${code}: ${stderr || 'unknown error'}`));
+        const detail = (stderr || stdout || 'unknown error').trim();
+        reject(new Error(`LibreOffice exited with code ${code}: ${detail}`));
         return;
       }
       resolve();
@@ -64,6 +98,13 @@ async function convertFileToPdf(sourcePath, originalName) {
   const finalPath = path.join(config.convertedDir, storedName);
   fs.copyFileSync(pdfPath, finalPath);
 
+  // Drop the temporary work copy of the Office file (and any LO sidecar junk).
+  try {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  } catch (_e) {
+    /* ignore */
+  }
+
   return {
     id,
     filename: `${path.basename(originalName || 'presentation', ext)}.pdf`,
@@ -71,6 +112,31 @@ async function convertFileToPdf(sourcePath, originalName) {
     publicUrl: `/converted/${storedName}`,
     size: fs.statSync(finalPath).size,
   };
+}
+
+function removeSourceOfficeFile(sourceId, { promotePdfId = null } = {}) {
+  if (!sourceId) return;
+  const db = getDb();
+  const source = db.prepare(`SELECT * FROM uploaded_files WHERE id = ?`).get(sourceId);
+  if (source) {
+    const ext = String(source.file_type || path.extname(source.filename || '') || '')
+      .toLowerCase()
+      .replace('.', '');
+    if (ext === 'ppt' || ext === 'pptx') {
+      if (source.file_path && fs.existsSync(source.file_path)) {
+        try {
+          fs.unlinkSync(source.file_path);
+        } catch (err) {
+          console.warn('Could not delete source Office file:', err.message);
+        }
+      }
+      db.prepare(`DELETE FROM uploaded_files WHERE id = ?`).run(sourceId);
+    }
+  }
+  if (promotePdfId) {
+    // Keep the PDF as a first-class library file (list filters converted_from_id IS NULL).
+    db.prepare(`UPDATE uploaded_files SET converted_from_id = NULL WHERE id = ?`).run(promotePdfId);
+  }
 }
 
 function enqueue(job) {
@@ -117,8 +183,9 @@ async function convertPresentation({ sourcePath, originalName, sourceId, uploade
       sourceId || null,
       uploadedBy || null
     );
+    // After a successful convert, drop the original PPT/PPTX (disk + DB row).
     if (sourceId) {
-      db.prepare(`UPDATE uploaded_files SET status = 'converted' WHERE id = ?`).run(sourceId);
+      removeSourceOfficeFile(sourceId, { promotePdfId: converted.id });
     }
     return {
       id: converted.id,
@@ -138,4 +205,4 @@ async function convertPresentation({ sourcePath, originalName, sourceId, uploade
   }
 }
 
-module.exports = { convertPresentation, convertFileToPdf };
+module.exports = { convertPresentation, convertFileToPdf, removeSourceOfficeFile };


### PR DESCRIPTION
## Summary
- Convert `.ppt` / `.pptx` to PDF during `POST /api/presentation-files` using LibreOffice, then return the PDF for presentation.
- After a successful conversion, delete the original Office file from disk and remove its DB row; keep only the PDF in storage/library.
- Raise default upload limit to **100 MB** (`MAX_UPLOAD_MB`).
- Harden headless LibreOffice with an isolated `UserInstallation` profile (fixes macOS “source file could not be loaded” / profile lock failures).
- Presentation UI shows converting progress and clearer errors when LibreOffice is missing.

## How to run
```bash
cd server
cp .env.example .env   # if needed
# Ensure:
#   ENABLE_HTTPS=true
#   MAX_UPLOAD_MB=100
#   LIBREOFFICE_BIN=/Applications/LibreOffice.app/Contents/MacOS/soffice   # macOS
#   # or: LIBREOFFICE_BIN=soffice / path to soffice on Linux
npm install
npm run migrate
npm run seed-admin
npm run generate-certs
npm start
```

Open https://localhost:3000/admin (not http:// or 0.0.0.0).

Default login: admin / cbrin123

Presentation: https://localhost:3000/presentation
Health: https://localhost:3000/api/health
LibreOffice is required for PowerPoint uploads. PDF uploads work without it.

## Test plan

- [ ] Upload a PDF → succeeds; file appears in Available files / Admin Manage Uploaded Files
- [ ] Upload a valid PPTX with LibreOffice installed → toast shows converting; response is PDF; original PPTX is gone from disk/Admin list
- [ ] Start Presentation on the converted PDF → admin display mirrors slides
- [ ] Upload PPTX without LibreOffice (or bad LIBREOFFICE_BIN) → clear 503 / install hint
- [ ] Upload a file > 100 MB → size-limit error mentioning 100 MB
- [ ] Invalid tiny/corrupt PPTX still fails conversion with a clear error
- [ ] Restart server after .env changes and confirm LIBREOFFICE_BIN is picked up